### PR TITLE
Fix version of makeit-derive after #2

### DIFF
--- a/makeit/Cargo.toml
+++ b/makeit/Cargo.toml
@@ -17,4 +17,4 @@ keywords = [
 ]
 
 [dependencies]
-makeit-derive = { version = "0.1.1", path = "../makeit-derive" }
+makeit-derive = { version = "0.1.2", path = "../makeit-derive" }


### PR DESCRIPTION
It hasn't been published yet so we don't need to bump the version.